### PR TITLE
feat: Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,12 +9,12 @@ Describe the big picture of your changes here to communicate to the maintainers 
 What types of changes does your code introduce? _Put an `x` in the boxes that
 apply_
 
-- [ ] A bug fix (non-breaking change which fixes an issue).
-- [ ] A new feature (non-breaking change which adds functionality).
-- [ ] A breaking change (fix or feature that would cause existing functionality
-      to not work as expected).
-- [ ] A non-productive update (documentation, tooling, etc. if none of the other
-      choices apply).
+- [ ] A **bug fix** (non-breaking change which fixes an issue).
+- [ ] A new **feature** (non-breaking change which adds functionality).
+- [ ] A **breaking change** (fix or feature that would cause existing
+      functionality to not work as expected).
+- [ ] A **non-productive** update (documentation, tooling, etc. if none of the
+      other choices apply).
 
 ## Checklist
 
@@ -24,9 +24,8 @@ help! This is simply a reminder of what we are going to look for before merging
 your code._
 
 - [ ] I have read the
-    [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md)
-    doc.
-<!-- - [ ] I have signed the CLA -->
+      [CONTRIBUTING](https://github.com/sdsc-order/rdf-protect/blob/master/CONTRIBUTING.md)
+      guidelines.
 - [ ] I have added tests that prove my fix is effective or that my feature
       works.
 - [ ] I have added the necessary documentation (if appropriate).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+**Thank you very much for considering contributing to this project!**
+
+We welcome any form of contribution:
+
+- New Issues (feature requests, bug reports, questions, ideas, ...)
+- Pull Requests (documentation improvements, code improvements, new features,
+  ...)
+
+**Note**: Before you take the time to open a pull request, please open an issue
+first. This will give us the chance to discuss any potential changes first.
+
+## Opening a Pull Request
+
+Pull requests are the best way to propose changes to the codebase. We actively
+welcome your pull requests:
+
+1. Fork the repo and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes: the CI will help you.
+5. Create the pull request.
+
+**Note:** Pull-requests can only be merged if the CI passes.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under this
+[license](LICENSE).
+
+## Important links
+
+- [Open Issues](https://github.com/sdsc-ordes/rdf-protect/issues)
+- [Open Pull Requests](https://github.com/sdsc-ordes/rdf-protect/pulls)
+- [Development Section in the README](https://github.com/sdsc-ordes/rdf-protect#development)
+- [LICENSE](https://github.com/sdsc-ordes/rdf-protect/blob/main/LICENSE)


### PR DESCRIPTION
## Contents

Playing around with some Best-Practices.
Comments welcome.

@supermaxiste, @cmdoret : Can we push this repo into a working mode where we try to apply as many Best Practices as possible. 
We are already doing nice, PRs have all a convention commit title.
Commits are conventional commits. When we merge, the commits on the branch should follow conv. commit message format, otherwise squash merge and make one proper description (I always do that). 
So we can just take this repository as a test piece with the team to see how far can we push it.
So CI will come. I would like to add one either on Github 
(prefer Gitlab because Github CI is akward with their actions setup, even unsecure too... I can give it a try, might be good too to not have predjustice, but among DevOps Github it does not have a good reputation)

 

