### PR TITLE
feat: Use stack-allocated trait object

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -8,12 +8,13 @@ use std::{
 pub fn get_buffer(path: &Path) -> BufReader<File> {
     return match File::open(&path) {
         Ok(file) => BufReader::new(file),
-        Err(e) => panic!("Cannot open file '{:?}': '{}'.", path, e),
+        Err(e) => panic!("Cannot open file '{path:?}': '{e}'."),
     };
 }
 
 // Parse RDF triples.
-pub fn parse_ntriples(reader: Box<dyn BufRead>) -> NTriplesParser<Box<dyn BufRead>> {
+// This function takes ownership of a generic type which implements `BufRead`.
+pub fn parse_ntriples(reader: impl BufRead) -> NTriplesParser<impl BufRead> {
     return NTriplesParser::new(reader);
 }
 

--- a/src/pass_second.rs
+++ b/src/pass_second.rs
@@ -21,10 +21,15 @@ fn process_triple(triple: &Triple) -> Result<(), TurtleError> {
 
 pub fn encrypt(log: &Logger, input: &Path, output: &Path, type_map_file: &Path) {
     // Construct the buffer either from `stdio` or from an input file.
-    // This object is constructed on the heap: `Box` and is a `trait object` (a dynamic dispatch)
-    let buffer: Box<dyn BufRead> = match input.to_str().unwrap() {
-        "-" => Box::new(BufReader::new(std::io::stdin())),
-        _ => Box::new(io::get_buffer(input)),
+    //
+    // This object is constructed on the stack and is a `trait object`.
+    // The wide-pointer `buffer` will have a pointer to the vtable
+    // and pointer to data on the stack.
+    // Normally that would be done with `Box::new(std::io::stdin())` on the heap, but since the
+    // newest version in Rust that also works on the stack (life-time extensions).
+    let buffer: &mut dyn BufRead = match input.to_str().unwrap() {
+        "-" => &mut BufReader::new(std::io::stdin()),
+        _ => &mut io::get_buffer(input),
     };
 
     let mut triples = io::parse_ntriples(buffer);


### PR DESCRIPTION
## Proposed Changes

- It is possible to create a wide-pointer to a trait object on the stack with newer Rust. This is possible because there is a feature called *lifetime extension*.
- Use this in the current code.

## Types of Changes

What types of changes does your code introduce? _Put an `x` in the boxes that
apply_

- [ ] A **bug fix** (non-breaking change which fixes an issue).
- [x] A new **feature** (non-breaking change which adds functionality).
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected).
- [ ] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply).

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/sdsc-order/rdf-protect/blob/master/CONTRIBUTING.md)
      guidelines.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation (if appropriate).

## Further Comments

Something I learned at the RustFest. =)