### PR TITLE
ci: correct nix path expressions

### DIFF
--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -36,13 +36,14 @@
   };
 
   outputs = {
+    self,
     nixpkgs,
     flake-utils,
     rust-overlay,
     ...
   }: let
-    # This is string (without toString it would be a `path` which is put into the store)
-    rootDir = toString ./. + "../../..";
+    lib = nixpkgs.lib;
+    rootDir = ./../..;
   in
     flake-utils.lib.eachDefaultSystem
     # Creates an attribute map `{ devShells.<system>.default = ...}`
@@ -53,7 +54,6 @@
 
         # Import nixpkgs and load it into pkgs.
         # Overlay the rust toolchain
-        lib = nixpkgs.lib;
         pkgs = import nixpkgs {
           inherit system overlays;
         };

--- a/tools/nix/pkgs/tripsu.nix
+++ b/tools/nix/pkgs/tripsu.nix
@@ -10,12 +10,12 @@
     rustc = rustToolchain;
   };
 
-  cargoFile = /. + rootDir + "/Cargo.toml";
-  lockFile = /. + rootDir + "/Cargo.lock";
+  cargoFile = rootDir + "/Cargo.toml";
+  lockFile = rootDir + "/Cargo.lock";
 in
   rustPlatform.buildRustPackage {
     name = "tripsu";
-    src = /. + rootDir;
+    src = rootDir;
 
     version = (lib.importTOML cargoFile).package.version;
 


### PR DESCRIPTION
## Proposed Changes

Correct some strange path expressions.
In `flake.nix`, all paths are directly converted to store paths: `rootDir = ./../..` will be a store path (check with `rootDir = builtins.trace ./../.. ./../..`)
The before syntax assumed that can be worked around which is wrong.

## Types of Changes

What types of changes does your code introduce? _Put an `x` in the boxes that
apply_

- [ ] A **bug fix** (non-breaking change which fixes an issue).
- [ ] A new **feature** (non-breaking change which adds functionality).
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected).
- [x] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply).

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/sdsc-ordes/tripsu/blob/master/CONTRIBUTING.md)
      guidelines.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation (if appropriate).

## Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->
