### PR TITLE
chore(ci): only use extra substituters

### DIFF
--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -2,19 +2,14 @@
   description = "tripsu";
 
   nixConfig = {
-    substituters = [ "https://cache.nixos.org" ];
-    extra-substituters = [
+    extra-trusted-substituters = [
+      "https://cache.nixos.org"
       "https://tripsu.cachix.org"
-      # Nix community's cache server
       "https://nix-community.cachix.org"
     ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "tripsu.cachix.org-1:pWZmirIwlMxGMVWSDMjQm4R+zLp8gtaT8OfH0Sv/j4E="
-    ];
-    extra-trusted-substituters = [
-      "https://tripsu.cachix.org"
-      "https://cache.nixos.org"
     ];
   };
 


### PR DESCRIPTION

## Proposed Changes

- Only add extra-substituters for enabling CI caching. Otherwise CI cannot add a extra substituter in `/etc/nix/nix.conf` (before eval. this flake) since the substituters are hard coded in here.

## Types of Changes

What types of changes does your code introduce? _Put an `x` in the boxes that
apply_

- [ ] A **bug fix** (non-breaking change which fixes an issue).
- [ ] A new **feature** (non-breaking change which adds functionality).
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected).
- [x] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply).

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/sdsc-ordes/tripsu/blob/master/CONTRIBUTING.md)
      guidelines.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation (if appropriate).

## Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->
