### PR TITLE
fix: added proper checking function for full URIs

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -280,7 +280,7 @@ pub fn match_object_rules(triple: &Triple, rules: &Rules, type_map: &mut TypeInd
             type_map,
             rules,
         ),
-        Subject::Triple(_) => panic!("RDF-star data not supported")
+        Subject::Triple(_) => panic!("RDF-star data not supported"),
     };
 
     if pseudo_object {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -14,7 +14,7 @@ pub struct NodeRules {
 
 impl NodeRules {
     /// Validate each full URI specified in the rules for nodes
-    pub fn check_uris(&self) -> Result<(), sophia_iri::InvalidIri> {
+    pub fn check_uris(&self) -> Result<(), anyhow::Error> {
         let node_uris = keep_full_uris(&self.of_type);
         check_uris(&node_uris)
     }
@@ -55,7 +55,7 @@ pub struct ObjectRules {
 
 impl ObjectRules {
     /// Validate each full URI specified in the rules for objects
-    pub fn check_uris(&self) -> Result<(), sophia_iri::InvalidIri> {
+    pub fn check_uris(&self) -> Result<(), anyhow::Error> {
         let on_predicate_uris = keep_full_uris(&self.on_predicate);
         check_uris(&on_predicate_uris)?;
         for (k, v) in self.on_type_predicate.iter() {
@@ -534,7 +534,6 @@ mod tests {
         "
         ));
         let expanded = rules.expand_rules_curie();
-        println!("Expanded rules: {:?} ", expanded.as_ref().unwrap());
         assert!(
             expanded.unwrap().objects.on_type_predicate[expanded_rule_type]
                 .contains(expanded_rule_predicate)

--- a/src/uris.rs
+++ b/src/uris.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use curie::{ExpansionError, InvalidPrefixError, PrefixMapping};
 use sophia_iri::Iri;
 use std::{
@@ -149,6 +150,15 @@ pub fn check_uri(uri: &str) -> Result<Iri<&str>, sophia_iri::InvalidIri> {
     Iri::new(&uri[1..uri.len() - 2])
 }
 
+
+pub fn check_full_uri(uri: &str) -> Result<(), anyhow::Error> {
+    // Ensure that full URI starts with "<" and ends with ">"
+    if !(uri.starts_with('<') && uri.ends_with('>')) {
+        return Err(anyhow!("Full URI in rules must start and end with angle brackets <...>. Please format {} into <{}>", uri, uri))
+    }
+    Ok(())
+}
+
 pub fn is_full_uri(uri: &str) -> bool {
     // Ensure that full URI starts with "<" and ends with ">"
     uri.starts_with('<') && uri.ends_with('>')
@@ -173,10 +183,11 @@ pub fn keep_full_uris(hash_set: &HashSet<String>) -> HashSet<String> {
         .collect();
 }
 
-pub fn check_uris(hash_set: &HashSet<String>) -> Result<(), sophia_iri::InvalidIri> {
+pub fn check_uris(hash_set: &HashSet<String>) -> Result<(), anyhow::Error> {
     // Check if the URIs in the HashSet are valid
 
     for uri in hash_set {
+        check_full_uri(uri)?;
         check_uri(uri)?;
     }
     Ok(())

--- a/src/uris.rs
+++ b/src/uris.rs
@@ -150,11 +150,10 @@ pub fn check_uri(uri: &str) -> Result<Iri<&str>, sophia_iri::InvalidIri> {
     Iri::new(&uri[1..uri.len() - 2])
 }
 
-
 pub fn check_full_uri(uri: &str) -> Result<(), anyhow::Error> {
     // Ensure that full URI starts with "<" and ends with ">"
     if !(uri.starts_with('<') && uri.ends_with('>')) {
-        return Err(anyhow!("Full URI in rules must start and end with angle brackets <...>. Please format {} into <{}>", uri, uri))
+        return Err(anyhow!("Full URI in rules must start and end with angle brackets <...>. Please format {} into <{}>", uri, uri));
     }
     Ok(())
 }


### PR DESCRIPTION
## Proposed Changes

Added a function to check full URIs and return an error when they're not enclosed by angle brackets.

## Types of Changes

What types of changes does your code introduce? _Put an `x` in the boxes that
apply_

- [x] A **bug fix** (non-breaking change which fixes an issue).
- [ ] A new **feature** (non-breaking change which adds functionality).
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected).
- [ ] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply).

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/sdsc-ordes/tripsu/blob/master/CONTRIBUTING.md)
      guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added the necessary documentation (if appropriate).

## Further Comments

With the example rules file from #67 we now get the following error:
```
Error expanding rules curie. Full URI in rules must start and end with angle brackets <...>. Please format http://xmlns.com/foaf/0.1/OnlineAccount into <http://xmlns.com/foaf/0.1/OnlineAccount>
```
